### PR TITLE
Limit start to avoid deep-pagination problems

### DIFF
--- a/docker/webapp.conf.tmpl
+++ b/docker/webapp.conf.tmpl
@@ -23,7 +23,7 @@ server {
         }
 
         # Limits on rows/start (by number of chars) to prevent deep paging craziness
-        if ($arg_start ~ ....+) {
+        if ($arg_start ~ .......+) {
             return 403;
         }
         if ($arg_rows ~ .....+) {
@@ -58,7 +58,7 @@ server {
         }
 
         # Limits on rows/start (by number of chars) to prevent deep paging craziness
-        if ($arg_start ~ ....+) {
+        if ($arg_start ~ ......+) {
             return 403;
         }
         if ($arg_rows ~ .....+) {

--- a/docker/webapp.conf.tmpl
+++ b/docker/webapp.conf.tmpl
@@ -23,9 +23,9 @@ server {
         }
 
         # Limits on rows/start (by number of chars) to prevent deep paging craziness
-        # if ($arg_start ~ ....+) {
-        #    return 403;
-        # }
+        if ($arg_start ~ ....+) {
+            return 403;
+        }
         if ($arg_rows ~ .....+) {
             return 403;
         }
@@ -58,9 +58,9 @@ server {
         }
 
         # Limits on rows/start (by number of chars) to prevent deep paging craziness
-        # if ($arg_start ~ ....+) {
-        #    return 403;
-        # }
+        if ($arg_start ~ ....+) {
+            return 403;
+        }
         if ($arg_rows ~ .....+) {
             return 403;
         }


### PR DESCRIPTION
it should not allow you to go beyond record 999999

It will pass with
> api?q=*:*&rows=50&start=999999&sort=updated%20asc&fq=updated:[0001-01-01T00:00:00Z%20TO%209999-12-31T23:59:59Z]

it will fail with
> api?q=*:*&rows=50&start=9999999&sort=updated%20asc&fq=updated:[0001-01-01T00:00:00Z%20TO%209999-12-31T23:59:59Z]